### PR TITLE
Update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 *.log
 *.gz
 *.DS_Store
+*.fdb_latexmk
+*.fls
 *.synctex.gz
 *.ipynb_checkpoints/
 .~lock*


### PR DESCRIPTION
Добавил в .gitignore файлы для latexmk, которые генерятся расширением VS Code Latex Workshop при сборке и потому не являются нужными в коммитах.